### PR TITLE
Doc: github obsolete, use gitlab

### DIFF
--- a/README
+++ b/README
@@ -1,3 +1,7 @@
+Note: this github repo is obsolete, use
+  https://gitlab.nic.cz/labs/bird
+
+================================================================================
                        BIRD Internet Routing Daemon
 
                      Home page  http://bird.network.cz/


### PR DESCRIPTION
This notice would help to reroute the Bird's users to gitlab.